### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ make
 ### Ubuntu
 
 ```
-sudo apt install ocaml
+sudo apt-get install ocaml ocaml-native-compilers
 make
 ```


### PR DESCRIPTION
Add the native compilers within the Ubuntu installation. 
In order to successfully install the cgum, `ocaml native compilers` are necessary. 
Updated the README to reflect this.